### PR TITLE
Further addressed comments in main PR

### DIFF
--- a/src/containerapp/azext_containerapp/_up_utils.py
+++ b/src/containerapp/azext_containerapp/_up_utils.py
@@ -488,7 +488,7 @@ class ContainerApp(Resource):  # pylint: disable=too-many-instance-attributes
         from datetime import datetime
 
         self.image = self.registry_server + "/" + image_name
-
+        # Creating a tag for the image using the current time to avoid overwriting customer's existing images
         now = datetime.now()
         tag_now_suffix = str(now).replace(" ", "").replace("-", "").replace(".", "").replace(":", "")
 

--- a/src/containerapp/azext_containerapp/_utils.py
+++ b/src/containerapp/azext_containerapp/_utils.py
@@ -1732,9 +1732,9 @@ def is_docker_running():
     try:
         # Run a simple 'docker stats --no-stream' command to check if the Docker daemon is running
         command = ["docker", "stats", "--no-stream"]
-        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        _, _ = process.communicate()
-        return process.returncode == 0
+        with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as process:
+            _, _ = process.communicate()
+            return process.returncode == 0
     except Exception:
         return False
 

--- a/src/containerapp/azext_containerapp/custom.py
+++ b/src/containerapp/azext_containerapp/custom.py
@@ -4495,6 +4495,7 @@ def patch_apply_handle_input(cmd, patch_check_list, method, pack_exec_path):
     # Track number of times patches were applied successfully.
     patch_apply_count = 0
     if input_method == "y":
+        telemetry_record_method = "y"
         for patch_check in patch_check_list:
             if patch_check["id"] and patch_check["newRunImage"]:
                 patch_cli_call(cmd,
@@ -4507,6 +4508,7 @@ def patch_apply_handle_input(cmd, patch_check_list, method, pack_exec_path):
                 # Increment patch_apply_count with every successful patch.
                 patch_apply_count += 1
     elif input_method == "n":
+        telemetry_record_method = "n"
         logger.warning("No patch applied.")
         return
     else:
@@ -4521,11 +4523,14 @@ def patch_apply_handle_input(cmd, patch_check_list, method, pack_exec_path):
                                patch_check["newRunImage"],
                                pack_exec_path)
                 patch_apply_count += 1
+                telemetry_record_method = input_method
                 break
         else:
+            telemetry_record_method = "invalid"
             logger.error("Invalid patch method or id.")
+    
     patch_apply_properties = {
-        'Context.Default.AzureCLI.UserResponse': input_method,
+        'Context.Default.AzureCLI.UserResponse': telemetry_record_method,
         'Context.Default.AzureCLI.PatchApplyCount': patch_apply_count
     }
     telemetry_core.add_extension_event('containerapp', patch_apply_properties)


### PR DESCRIPTION
Further addressed comments in the main PR:

1. Added code comments to explain some of the functions
2. Improved readability in the telemetry part
3. Flattened nested if else statements and removed suppressed linting error
4. Changed some prompts from using `print` to using `logger`. Depending on the level of urgency, some prompts are displayed with `warning`, `error`, `debug`, and `info`. Some crucial prompts such as displaying list of patchable check result continue to use `print`.